### PR TITLE
Add cancel_job method to jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ The JSON response will contain the new status of the job (generally "Active"), a
 }
 ```
 
+#### `jobs.cancel_job`
+
+To cancel a job, first get a token (hopefully from persistent storage), then call jobs.cancel_job(). This should be used with extreme care in production, and is only useful in cleaning up trainbeacon in bulk.
+
+```
+from pybeacon import beacon_auth
+from pybeacon import jobs
+
+token = beacon_auth.get_api_token(USERNAME, PASSWORD, BEACON_URL)
+
+job = jobs.cancel_job(token.get('accessToken'), JOB_ID, BEACON_API_URL)
+```
+
+The JSON response will contain the new job details as per jobs.get_job
+```
+
 ### `jobs.get_job`
 
 To get the details of a job, first get a token (hopefully you've already persisted one somewhere), then call jobs.get_job().

--- a/pybeacon/jobs.py
+++ b/pybeacon/jobs.py
@@ -27,3 +27,12 @@ def acknowledge_job(access_token, job_id, beacon_api_url="https://apibeacon.ses.
     response = requests.post(beacon_api_url + '/Api/v1/Jobs/{}/Acknowledge'.format(job_id),
                              headers=headers)
     return response.json()
+
+# Cancels the specified job, returns job details
+# Example response: {"Id":2,"Name":"Active","Description":"Job is under active management"}
+def cancel_job(access_token, job_id, beacon_api_url="https://apitrainbeacon.ses.nsw.gov.au"):
+    job_id = format_job_id(job_id)
+    headers = {'Authorization': 'Bearer {}'.format(access_token), 'Content-Type': 'application/x-www-form-urlencoded'}
+    body = {'Text':'Bulk Cancel','Date': datetime.now().isoformat()}
+    response = requests.post(beacon_api_url + '/Api/v1/Jobs/{}/Cancel'.format(job_id),headers=headers,data=body)
+    return response.json()


### PR DESCRIPTION
Added a cancel_job method to jobs which calls on the Cancel API in beacon.

This should only be used for trainbeacon (but could work in prod).